### PR TITLE
GHA: fix branch name

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -3,7 +3,7 @@ name: Dev Build and Publish
 on:
   push:
     branches:
-    - master
+    - main
 
 jobs:
   build-for-dev:


### PR DESCRIPTION
    - we should use `main` instead `master`