### PR TITLE
GHA: fix secret

### DIFF
--- a/.github/workflows/factory.yml
+++ b/.github/workflows/factory.yml
@@ -37,8 +37,8 @@ jobs:
       if: ${{ inputs.push == true }}
       with:
         secrets: |
-          secret/data/github/repo/harvester/${{ github.repository }}/dockerhub/harvester/credentials username  | DOCKER_USERNAME ;
-          secret/data/github/repo/harvester/${{ github.repository }}/dockerhub/harvester/credentials password  | DOCKER_PASSWORD
+          secret/data/github/repo/${{ github.repository }}/dockerhub/harvester/credentials username  | DOCKER_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/dockerhub/harvester/credentials password  | DOCKER_PASSWORD
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       if: ${{ inputs.push == true }}


### PR DESCRIPTION
    - the `${{ github.repository }}` already contains the full repo
      name, e.g. `harvester/csi-driver-lvm`