### PR TITLE
deploy: add lvm-snapshot snapshotclass as default

### DIFF
--- a/deploy/charts/templates/snapshotclass.yaml
+++ b/deploy/charts/templates/snapshotclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: snapshot.storage.k8s.io/v1
+deletionPolicy: Delete
+driver: lvm.driver.harvesterhci.io
+kind: VolumeSnapshotClass
+metadata:
+  name: lvm-snapshot


### PR DESCRIPTION
We could make a default `snapshotclass` for our lvm provisioner.