### PR TITLE
GHA: pin GH Actions to commit sha

### DIFF
--- a/.github/workflows/factory.yml
+++ b/.github/workflows/factory.yml
@@ -22,33 +22,33 @@ jobs:
       id-token: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Run dapper
       run: make ci
 
     - name: Read some Secrets
-      uses: rancher-eio/read-vault-secrets@main
+      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
       if: ${{ inputs.push == true }}
       with:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/dockerhub/harvester/credentials username  | DOCKER_USERNAME ;
           secret/data/github/repo/${{ github.repository }}/dockerhub/harvester/credentials password  | DOCKER_PASSWORD
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       if: ${{ inputs.push == true }}
       with:
         username: ${{ env.DOCKER_USERNAME }}
         password: ${{ env.DOCKER_PASSWORD }}
 
     - name: Docker Build (CSI Plugin)
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         provenance: false
         context: .
@@ -58,7 +58,7 @@ jobs:
         tags: ${{ env.repo }}/${{ env.pluginImageName }}:${{ inputs.tag }}
 
     - name: Docker Build (LVM Provisioner)
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         provenance: false
         context: .
@@ -68,7 +68,7 @@ jobs:
         tags: ${{ env.repo }}/${{ env.provisionerImageName }}:${{ inputs.tag }}
 
     - name: Docker Build (LVM Webhook)
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         provenance: false
         context: .


### PR DESCRIPTION
This PR is part of an org-wide effort to pin GHA action references to immutable commit SHAs. It contains results from the RST pin-gha-to-sha.sh script where any uses: references to tags or branches are replaced by immutable commit SHAs.

Related to https://github.com/harvester/harvester/issues/10279