### PR TITLE
chore: bump golang 1.26

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,5 +1,5 @@
 
-FROM golang:1.25.7-bookworm
+FROM golang:1.26-bookworm
 
 ARG DAPPER_HOST_ARCH
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ## install golangci
-COPY --from=golangci/golangci-lint:v2.11.4-alpine@sha256:72bcd68512b4e27540dd3a778a1b7afd45759d8145cfb3c089f1d7af53e718e9 /usr/bin/golangci-lint /usr/local/bin/golangci-lint
+COPY --from=golangci/golangci-lint:v2.12.2-alpine@sha256:91b27804074a0bacea298707f016911e60cf0cdbc6c7bf5ccacb5f0606d18d60 /usr/bin/golangci-lint /usr/local/bin/golangci-lint
 
 ENV DAPPER_ENV="REPO TAG"
 ENV DAPPER_SOURCE=/go/src/github.com/harvester/csi-driver-lvm

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/csi-driver-lvm
 
-go 1.25.7
+go 1.26
 
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.3.1


### PR DESCRIPTION
    - also bump golangci-lint 2.12.2

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
bump golang 1.26

#### Solution:
bump golang 1.26

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10734

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
