### PR TITLE
feat: expose thin-pool chunk_size, metadata size, and zeroing as StorageClass params

### DIFF
--- a/cmd/provisioner/clonelv.go
+++ b/cmd/provisioner/clonelv.go
@@ -115,7 +115,11 @@ func clonelv(c *cli.Context) error {
 	}
 	defer src.Close()
 
-	output, err := lvm.CreateLVS(dstVGName, dstLV, dstSize, dstLVType)
+	// Clone always targets an existing thin pool (created earlier by the first
+	// non-clone PVC on this VG). Pass empty strings for the pool-creation
+	// parameters - CreateLVS will skip the lvcreate --thinpool call entirely
+	// once it detects the pool already exists.
+	output, err := lvm.CreateLVS(dstVGName, dstLV, dstSize, dstLVType, "", "", "")
 	if err != nil {
 		return fmt.Errorf("unable to create lv: %w output:%s", err, output)
 	}

--- a/cmd/provisioner/createlv.go
+++ b/cmd/provisioner/createlv.go
@@ -30,6 +30,18 @@ func createLVCmd() *cli.Command {
 				Name:  flagLVMType,
 				Usage: "Required. type of lvs, can be either striped or mirrored",
 			},
+			&cli.StringFlag{
+				Name:  flagChunkSize,
+				Usage: "Optional. Thin-pool chunk size passed to lvcreate --chunksize (e.g. 512K, 1M). Applied only on first-time thin-pool creation.",
+			},
+			&cli.StringFlag{
+				Name:  flagPoolMetadataSize,
+				Usage: "Optional. Thin-pool metadata LV size passed to lvcreate --poolmetadatasize (e.g. 16G). Applied only on first-time thin-pool creation.",
+			},
+			&cli.StringFlag{
+				Name:  flagZeroBlocks,
+				Usage: "Optional. Whether to zero newly-allocated thin-pool blocks (true|false). Maps to lvcreate --zero. Applied only on first-time thin-pool creation.",
+			},
 		},
 		Action: func(c *cli.Context) error {
 			if err := createLV(c); err != nil {
@@ -58,8 +70,12 @@ func createLV(c *cli.Context) error {
 	if lvmType == "" {
 		return fmt.Errorf("invalid empty flag %v", flagLVMType)
 	}
+	chunkSize := c.String(flagChunkSize)
+	poolMetadataSize := c.String(flagPoolMetadataSize)
+	zeroBlocks := c.String(flagZeroBlocks)
 
-	klog.Infof("create lv %s size:%d vg:%s type:%s", lvName, lvSize, vgName, lvmType)
+	klog.Infof("create lv %s size:%d vg:%s type:%s chunkSize:%q poolMetadataSize:%q zeroBlocks:%q",
+		lvName, lvSize, vgName, lvmType, chunkSize, poolMetadataSize, zeroBlocks)
 
 	if !lvm.VgExists(vgName) {
 		lvm.VgActivate()
@@ -69,7 +85,7 @@ func createLV(c *cli.Context) error {
 		}
 	}
 
-	output, err := lvm.CreateLVS(vgName, lvName, lvSize, lvmType)
+	output, err := lvm.CreateLVS(vgName, lvName, lvSize, lvmType, chunkSize, poolMetadataSize, zeroBlocks)
 	if err != nil {
 		return fmt.Errorf("unable to create lv: %w output:%s", err, output)
 	}

--- a/cmd/provisioner/main.go
+++ b/cmd/provisioner/main.go
@@ -18,6 +18,9 @@ const (
 	flagSrcLVName          = "srclvname"
 	flagSrcVGName          = "srcvgname"
 	flagSrcType            = "srctype"
+	flagChunkSize          = "chunksize"
+	flagPoolMetadataSize   = "poolmetadatasize"
+	flagZeroBlocks         = "zeroblocks"
 	createSnapshotForClone = true
 	snapshotPrefix         = "lvm-snapshot-"
 )

--- a/deploy/charts/templates/storageclass.yaml
+++ b/deploy/charts/templates/storageclass.yaml
@@ -1,0 +1,55 @@
+{{- /*
+Render StorageClasses declared in values.yaml under `storageClasses:`.
+
+Each key under storageClasses may specify:
+  enabled              (bool)   whether to render this StorageClass
+  type                 (string) LVM type: "dm-thin" or "striped"
+  chunkSize            (string) thin-pool --chunksize (dm-thin only, first-PVC only)
+  poolMetadataSize     (string) thin-pool --poolmetadatasize (dm-thin only, first-PVC only)
+  zeroBlocks           (string) "true" or "false" (dm-thin only, first-PVC only)
+  reclaimPolicy        (string) Delete or Retain (default Delete)
+  volumeBindingMode    (string) WaitForFirstConsumer or Immediate (default WaitForFirstConsumer)
+  allowVolumeExpansion (bool)   default true
+  vgName               (string) optional; if unset, users must set it per-namespace via UI or by editing the SC
+
+Only "type" is strictly required to render.
+
+Note: chunk_size CANNOT be changed after the thin pool is created. Pick the
+right value before workloads start writing. See docs/advanced/addons/lvm-local-storage.md.
+*/ -}}
+
+{{- range $name, $sc := .Values.storageClasses }}
+{{- if $sc.enabled }}
+{{- if $sc.type }}
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ $name }}
+  {{- with $sc.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+provisioner: {{ $.Values.lvm.driverName }}
+parameters:
+  type: {{ $sc.type | quote }}
+  {{- if $sc.vgName }}
+  vgName: {{ $sc.vgName | quote }}
+  {{- end }}
+  {{- if eq $sc.type "dm-thin" }}
+  {{- if $sc.chunkSize }}
+  chunkSize: {{ $sc.chunkSize | quote }}
+  {{- end }}
+  {{- if $sc.poolMetadataSize }}
+  poolMetadataSize: {{ $sc.poolMetadataSize | quote }}
+  {{- end }}
+  {{- if hasKey $sc "zeroBlocks" }}
+  zeroBlocks: {{ $sc.zeroBlocks | quote }}
+  {{- end }}
+  {{- end }}
+reclaimPolicy: {{ default "Delete" $sc.reclaimPolicy }}
+volumeBindingMode: {{ default "WaitForFirstConsumer" $sc.volumeBindingMode }}
+allowVolumeExpansion: {{ default true $sc.allowVolumeExpansion }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/values.yaml
+++ b/deploy/charts/values.yaml
@@ -45,18 +45,19 @@ storageClasses:
   # chunkSize, poolMetadataSize, and zeroBlocks are honored ONLY on the very
   # first PVC that causes the pool to be created. They CANNOT be changed
   # after the pool exists - destroying and recreating the pool is the only
-  # way to change them. Defaults chosen per LVM upstream `performance`
-  # policy and Linux dm-thin admin guide guidance. See
-  # docs/advanced/addons/lvm-local-storage.md for the full rationale.
+  # way to change them. Defaults chosen to align with the full-stripe width
+  # of common hardware-RAID layouts (see
+  # docs/advanced/addons/lvm-local-storage.md for the full rationale).
   harvester-lvm-thin:
     enabled: true
     type: dm-thin
-    # 512K matches LVM's upstream `performance` policy seed and the kernel
-    # dm-thin admin guide's general-purpose recommendation. Good up to 128TB
-    # pools. Override to 128K for snapshot-heavy tenants (halves CoW cost).
-    # Never exceed 2M (Red Hat Gluster's documented CoW-friendliness cap).
-    chunkSize: "512K"
-    # 16G covers pools up to 128TB at 512K chunks with headroom. Formula:
+    # 1M aligns with the full-stripe width of common hardware-RAID layouts
+    # (e.g. 4 data disks x 256K strip = 1M stripe), so each chunk allocation
+    # maps to whole stripes and avoids partial-stripe read-modify-write. A
+    # sub-stripe chunk (e.g. 512K on a 1M stripe) also widens the RAID5/6
+    # write hole. Override to your RAID full-stripe width; never exceed 2M.
+    chunkSize: "1M"
+    # 16G covers pools up to 256TB at 1M chunks with headroom. Formula:
     # metadata_bytes = 64 * (pool_size / chunk_size).
     poolMetadataSize: "16G"
     # "false" adds --zero n at pool creation, disabling per-chunk zeroing on

--- a/deploy/charts/values.yaml
+++ b/deploy/charts/values.yaml
@@ -39,18 +39,63 @@ kubernetes:
   kubeletPath: /var/lib/kubelet
 
 storageClasses:
-  linear:
+  # harvester-lvm-thin: dm-thin (thin-provisioned) pool. Recommended default
+  # for VM workloads. Snapshot-friendly, over-provisions physical space.
+  #
+  # chunkSize, poolMetadataSize, and zeroBlocks are honored ONLY on the very
+  # first PVC that causes the pool to be created. They CANNOT be changed
+  # after the pool exists - destroying and recreating the pool is the only
+  # way to change them. Defaults chosen per LVM upstream `performance`
+  # policy and Linux dm-thin admin guide guidance. See
+  # docs/advanced/addons/lvm-local-storage.md for the full rationale.
+  harvester-lvm-thin:
     enabled: true
+    type: dm-thin
+    # 512K matches LVM's upstream `performance` policy seed and the kernel
+    # dm-thin admin guide's general-purpose recommendation. Good up to 128TB
+    # pools. Override to 128K for snapshot-heavy tenants (halves CoW cost).
+    # Never exceed 2M (Red Hat Gluster's documented CoW-friendliness cap).
+    chunkSize: "512K"
+    # 16G covers pools up to 128TB at 512K chunks with headroom. Formula:
+    # metadata_bytes = 64 * (pool_size / chunk_size).
+    poolMetadataSize: "16G"
+    # "false" adds --zero n at pool creation, disabling per-chunk zeroing on
+    # allocation. Recommended for single-tenant clusters; halves write
+    # amplification on first writes to unallocated regions.
+    zeroBlocks: "false"
     additionalAnnotations: []
     # this might be used to mark one of the StorageClasses as default:
     # storageclass.kubernetes.io/is-default-class: "true"
     reclaimPolicy: Delete
-  striped:
+    volumeBindingMode: WaitForFirstConsumer
+    allowVolumeExpansion: true
+  # harvester-lvm-striped: striped (fat-provisioned) volumes. Each PVC
+  # allocates its full requested capacity up front. No thin-pool involved,
+  # so chunkSize/poolMetadataSize/zeroBlocks do not apply.
+  harvester-lvm-striped:
     enabled: true
+    type: striped
+    additionalAnnotations: []
+    reclaimPolicy: Delete
+    volumeBindingMode: WaitForFirstConsumer
+    allowVolumeExpansion: true
+
+  # Legacy keys - retained for backwards compatibility with charts that
+  # were referencing them by name. Left disabled by default; the two entries
+  # above are the recommended way to consume this chart going forward.
+  linear:
+    enabled: false
+    type: striped
+    additionalAnnotations: []
+    reclaimPolicy: Delete
+  striped:
+    enabled: false
+    type: striped
     additionalAnnotations: []
     reclaimPolicy: Delete
   mirror:
-    enabled: true
+    enabled: false
+    type: striped
     additionalAnnotations: []
     reclaimPolicy: Delete
 

--- a/examples/storageclass-dm-thin.yaml
+++ b/examples/storageclass-dm-thin.yaml
@@ -12,9 +12,9 @@ parameters:
   #
   # See https://docs.harvesterhci.io/latest/advanced/addons/lvm-local-storage
   # for the full rationale and tuning guidance.
-  chunkSize: "512K"          # LVM upstream `performance` policy seed.
-                             # 128K for snapshot-heavy tenants. Never >2M.
-  poolMetadataSize: "16G"    # covers pools up to ~128TB at 512K chunks
+  chunkSize: "1M"            # Align to RAID full-stripe width (data disks x
+                             # strip); 1M suits common layouts. Never >2M.
+  poolMetadataSize: "16G"    # covers pools up to ~256TB at 1M chunks
   zeroBlocks: "false"        # single-tenant: skip zero-on-allocate (fast)
 provisioner: lvm.driver.harvesterhci.io
 reclaimPolicy: Delete

--- a/examples/storageclass-dm-thin.yaml
+++ b/examples/storageclass-dm-thin.yaml
@@ -6,6 +6,16 @@ metadata:
 parameters:
   type: dm-thin
   vgName: vg01
+  # Thin-pool creation parameters. Honored only on the very first PVC that
+  # causes the pool to be created; ignored for subsequent PVCs against the
+  # same pool. Cannot be changed after the pool exists.
+  #
+  # See https://docs.harvesterhci.io/latest/advanced/addons/lvm-local-storage
+  # for the full rationale and tuning guidance.
+  chunkSize: "512K"          # LVM upstream `performance` policy seed.
+                             # 128K for snapshot-heavy tenants. Never >2M.
+  poolMetadataSize: "16G"    # covers pools up to ~128TB at 512K chunks
+  zeroBlocks: "false"        # single-tenant: skip zero-on-allocate (fast)
 provisioner: lvm.driver.harvesterhci.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer

--- a/pkg/lvm/controllerserver.go
+++ b/pkg/lvm/controllerserver.go
@@ -115,17 +115,29 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, status.Error(codes.InvalidArgument, "cannot have both block and mount access type")
 	}
 
-	lvmType := req.GetParameters()["type"]
+	params := req.GetParameters()
+
+	lvmType := params["type"]
 	if lvmType != "striped" && lvmType != "dm-thin" {
 		return nil, status.Errorf(codes.Internal, "lvmType is incorrect: %s", lvmType)
 	}
 
-	vgName := req.GetParameters()["vgName"]
+	vgName := params["vgName"]
 	if vgName == "" {
 		return nil, status.Error(codes.InvalidArgument, "vgName is missing, please check the storage class")
 	}
 
-	volumeContext := req.GetParameters()
+	// Thin-pool creation parameters. Honored only when this PVC ends up creating
+	// the pool for the first time; ignored for subsequent PVCs on the same pool.
+	// Empty string preserves LVM's built-in default for that flag - which for
+	// chunkSize is undesirable on multi-TB pools (LVM auto-selects 8-16 MiB
+	// chunks, causing severe write amplification on random 4K workloads).
+	// StorageClasses shipped with this chart set explicit defaults.
+	chunkSize := params["chunkSize"]
+	poolMetadataSize := params["poolMetadataSize"]
+	zeroBlocks := params["zeroBlocks"]
+
+	volumeContext := params
 	size := strconv.FormatInt(req.GetCapacityRange().GetRequiredBytes(), 10)
 
 	volumeContext["RequiredBytes"] = size
@@ -177,6 +189,9 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			namespace:        cs.namespace,
 			vgName:           vgName,
 			hostWritePath:    cs.hostWritePath,
+			chunkSize:        chunkSize,
+			poolMetadataSize: poolMetadataSize,
+			zeroBlocks:       zeroBlocks,
 		}
 		if err := createProvisionerPod(ctx, va); err != nil {
 			klog.Errorf("error creating provisioner pod :%v", err)

--- a/pkg/lvm/lvm.go
+++ b/pkg/lvm/lvm.go
@@ -80,6 +80,12 @@ type volumeAction struct {
 	vgName           string
 	hostWritePath    string
 	srcInfo          *srcInfo
+	// Thin-pool creation parameters. Only used on the very first PVC that
+	// causes the pool to be created; ignored on subsequent PVCs against the
+	// same pool. Empty values fall back to LVM's built-in defaults.
+	chunkSize        string
+	poolMetadataSize string
+	zeroBlocks       string
 	//srcDev           string
 }
 
@@ -353,6 +359,15 @@ func createProvisionerPod(ctx context.Context, va volumeAction) (err error) {
 	switch va.action {
 	case actionTypeCreate:
 		args = append(args, "createlv", "--lvsize", fmt.Sprintf("%d", va.size), "--lvmtype", va.lvmType, "--vgname", va.vgName)
+		if va.chunkSize != "" {
+			args = append(args, "--chunksize", va.chunkSize)
+		}
+		if va.poolMetadataSize != "" {
+			args = append(args, "--poolmetadatasize", va.poolMetadataSize)
+		}
+		if va.zeroBlocks != "" {
+			args = append(args, "--zeroblocks", va.zeroBlocks)
+		}
 	case actionTypeDelete:
 		args = append(args, "deletelv", "--srcvgname", va.srcInfo.srcVGName, "--srctype", va.srcInfo.srcType)
 	case actionTypeClone:
@@ -434,8 +449,39 @@ func VgActivate() {
 	}
 }
 
-// CreateLVS creates the new volume, used by lvcreate provisioner pod
-func CreateLVS(vg string, name string, size uint64, lvmType string) (string, error) {
+// buildThinPoolCreateArgs assembles the lvcreate command line for a first-time
+// thin-pool creation. Any argument passed as an empty string is omitted so LVM
+// falls back to its built-in default for that flag. zeroBlocks accepts "true"
+// or "false" (case-insensitive) and is translated to lvcreate's "--zero y|n".
+func buildThinPoolCreateArgs(vg, thinPoolName, chunkSize, poolMetadataSize, zeroBlocks string) []string {
+	args := []string{"-l90%FREE", "--thinpool", thinPoolName}
+	if chunkSize != "" {
+		args = append(args, "--chunksize", chunkSize)
+	}
+	if poolMetadataSize != "" {
+		args = append(args, "--poolmetadatasize", poolMetadataSize)
+	}
+	if zeroBlocks != "" {
+		zeroFlag := "y"
+		if strings.EqualFold(zeroBlocks, "false") {
+			zeroFlag = "n"
+		}
+		args = append(args, "--zero", zeroFlag)
+	}
+	args = append(args, vg)
+	return args
+}
+
+// CreateLVS creates the new volume, used by lvcreate provisioner pod.
+//
+// chunkSize, poolMetadataSize, and zeroBlocks apply only when the thin pool is
+// being created for the first time (lvmType == dm-thin and the pool does not
+// yet exist). Empty strings leave the corresponding lvcreate flag unset so LVM
+// falls back to its built-in defaults - which is undesirable for chunk_size on
+// large pools (LVM auto-selects 8-16 MiB for multi-TB pools, causing severe
+// write amplification on random 4K workloads). Callers should pass explicit
+// values from the StorageClass parameters.
+func CreateLVS(vg, name string, size uint64, lvmType, chunkSize, poolMetadataSize, zeroBlocks string) (string, error) {
 
 	if lvExists(vg, name) {
 		klog.Infof("logicalvolume: %s already exists\n", name)
@@ -458,7 +504,7 @@ func CreateLVS(vg string, name string, size uint64, lvmType string) (string, err
 			return "", fmt.Errorf("unable to determine if thinpool exists: %w", err)
 		}
 		if !found {
-			args := []string{"-l90%FREE", "--thinpool", thinPoolName, vg}
+			args := buildThinPoolCreateArgs(vg, thinPoolName, chunkSize, poolMetadataSize, zeroBlocks)
 			klog.Infof("lvcreate %s", args)
 			_, err := executor.Execute("lvcreate", args)
 			if err != nil {

--- a/pkg/lvm/lvm_test.go
+++ b/pkg/lvm/lvm_test.go
@@ -1,0 +1,78 @@
+package lvm
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildThinPoolCreateArgs(t *testing.T) {
+	const vg = "vmvg"
+	const pool = "vmvg-thinpool"
+
+	tests := []struct {
+		name             string
+		chunkSize        string
+		poolMetadataSize string
+		zeroBlocks       string
+		want             []string
+	}{
+		{
+			name: "all empty preserves current behavior (LVM auto-select)",
+			want: []string{"-l90%FREE", "--thinpool", pool, vg},
+		},
+		{
+			name:      "chunk size only",
+			chunkSize: "512K",
+			want:      []string{"-l90%FREE", "--thinpool", pool, "--chunksize", "512K", vg},
+		},
+		{
+			name:             "chart defaults - 512K chunks, 16G metadata, no zeroing",
+			chunkSize:        "512K",
+			poolMetadataSize: "16G",
+			zeroBlocks:       "false",
+			want: []string{
+				"-l90%FREE", "--thinpool", pool,
+				"--chunksize", "512K",
+				"--poolmetadatasize", "16G",
+				"--zero", "n",
+				vg,
+			},
+		},
+		{
+			name:       "zeroBlocks=true maps to --zero y",
+			zeroBlocks: "true",
+			want:       []string{"-l90%FREE", "--thinpool", pool, "--zero", "y", vg},
+		},
+		{
+			name:       "zeroBlocks is case-insensitive",
+			zeroBlocks: "FALSE",
+			want:       []string{"-l90%FREE", "--thinpool", pool, "--zero", "n", vg},
+		},
+		{
+			name:       "unknown zeroBlocks value defaults to --zero y (safe: LVM's own default)",
+			zeroBlocks: "maybe",
+			want:       []string{"-l90%FREE", "--thinpool", pool, "--zero", "y", vg},
+		},
+		{
+			name:             "snapshot-heavy override: 128K chunks",
+			chunkSize:        "128K",
+			poolMetadataSize: "4G",
+			zeroBlocks:       "false",
+			want: []string{
+				"-l90%FREE", "--thinpool", pool,
+				"--chunksize", "128K",
+				"--poolmetadatasize", "4G",
+				"--zero", "n",
+				vg,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildThinPoolCreateArgs(vg, pool, tt.chunkSize, tt.poolMetadataSize, tt.zeroBlocks)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildThinPoolCreateArgs()\n got:  %v\n want: %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/lvm/lvm_test.go
+++ b/pkg/lvm/lvm_test.go
@@ -26,13 +26,13 @@ func TestBuildThinPoolCreateArgs(t *testing.T) {
 			want:      []string{"-l90%FREE", "--thinpool", pool, "--chunksize", "512K", vg},
 		},
 		{
-			name:             "chart defaults - 512K chunks, 16G metadata, no zeroing",
-			chunkSize:        "512K",
+			name:             "chart defaults - 1M chunks, 16G metadata, no zeroing",
+			chunkSize:        "1M",
 			poolMetadataSize: "16G",
 			zeroBlocks:       "false",
 			want: []string{
 				"-l90%FREE", "--thinpool", pool,
-				"--chunksize", "512K",
+				"--chunksize", "1M",
 				"--poolmetadatasize", "16G",
 				"--zero", "n",
 				vg,


### PR DESCRIPTION
## Summary

The driver previously ran `lvcreate --thinpool` with only `-l90%FREE`, letting LVM auto-select all pool creation parameters. LVM's `generic` chunk_size policy scales chunk_size with pool size to keep metadata bounded — so multi-TB pools land on 8-16 MiB chunks by design. On random 4K workloads this produces up to a **4096:1** allocation write-amp — severe enough that a field customer measured **326 random 4K IOPS on hardware capable of at least 10x that**.

This PR exposes three new StorageClass parameters honored at first-time pool creation and ships sensible defaults through the chart.

## Changes

**Driver (`pkg/lvm`, `cmd/provisioner`):**
- `CreateLVS` signature extended with `chunkSize, poolMetadataSize, zeroBlocks string`.
- New helper `buildThinPoolCreateArgs` assembles the `lvcreate` line and omits any flag whose value is the empty string (preserves backwards compat).
- `controllerserver.go` extracts the three new parameters from `StorageClass.parameters`.
- `cmd/provisioner/createlv.go` grows three matching CLI flags.
- `cmd/provisioner/clonelv.go` passes empty strings (thin pool always exists at clone time, so pool-creation flags are moot).

**Chart (`deploy/charts`):**
- New `templates/storageclass.yaml` renders the `storageClasses:` values block (previously declared but never rendered).
- Two SCs shipped by default:
  - `harvester-lvm-thin` — `type: dm-thin`, with `chunkSize: 1M`, `poolMetadataSize: 16G`, `zeroBlocks: false`
  - `harvester-lvm-striped` — `type: striped`, no thin-pool params
- Legacy `linear`/`striped`/`mirror` keys retained (disabled by default) for backwards compat.

**Example (`examples/storageclass-dm-thin.yaml`):**
- Documents the three new parameters inline with tuning guidance.

**Tests (`pkg/lvm/lvm_test.go`, new):**
- Table-driven tests for `buildThinPoolCreateArgs` covering empty (auto-select), full (chart defaults), case-insensitive zeroBlocks, and edge cases. 7 subtests, all pass.

## Why 1M default

Harvester runs predominantly on **hardware-RAID-backed** volume groups, where the dominant factor is stripe alignment, not the general-purpose seed. A chunk equal to the RAID full-stripe width — (number of data disks) × (strip size) — makes every first-touch allocation a whole-stripe write. A sub-stripe chunk (for example `512K` on a 1 MiB stripe) forces partial-stripe **read-modify-write** and, on parity RAID (5/6), widens the write-hole window, so an unclean shutdown without a protected controller cache (BBU/FBWC) can leave a stripe with inconsistent parity.

`1M` aligns with the most common power-of-two layouts (e.g. 4 data disks × 256 KiB strip = 1 MiB stripe), matches the fixed 1 MiB block used by mainstream hypervisor stacks, and stays under the 2 MiB CoW cap:

| Source | Block / chunk |
|---|---|
| VMware VMFS-5/6 | **1 MiB** (fixed) |
| Nutanix AHV | **1 MiB** vBlock (fixed) |
| [LVM upstream `performance` policy](https://github.com/lvmteam/lvm2/blob/master/lib/config/defaults.h) | 512 KiB seed (general-purpose, RAID-agnostic) |
| [Linux kernel dm-thin admin guide](https://docs.kernel.org/admin-guide/device-mapper/thin-provisioning.html) | "512 KiB general; 64 KiB snapshot-heavy" |
| [Red Hat Gluster admin guide](https://docs.redhat.com/en/documentation/red_hat_gluster_storage/3.5/html/administration_guide/chap-configuring_red_hat_storage_for_enhancing_performance) | cap at **2 MiB** "to reduce COW problems" |

Operators whose RAID full stripe differs (e.g. a 3-data-disk RAID5 = 768 KiB, or a single-disk / non-RAID VG where alignment does not apply) should override `chunkSize` to match; snapshot-heavy tenants can drop to `128K`.

## Why 16G metadata default

Metadata bytes per chunk ≈ 64. So `metadata_size ≈ 64 × (pool_size / chunk_size)`. At 1M chunks:

| Pool size | Metadata needed | Fits in 16G? |
|---:|---:|---:|
| 64 TB | ~4 GB | ✅ |
| 128 TB | ~8 GB | ✅ |
| 256 TB | ~16 GB | ✅ (at limit) |

A larger chunk needs less metadata to address the same capacity, so moving from 512K to 1M doubles the pool size that 16G covers — the entire practical Harvester deployment range with headroom.

## Why `zeroBlocks: false` default

Adds `--zero n` at pool creation, disabling per-chunk zero-write on allocation. On single-tenant Harvester nodes this halves the write-amp on first-touch to unallocated regions. Multi-tenant clusters that care about inter-tenant data-leak isolation can opt in with `zeroBlocks: true`.

## Backwards compatibility

- Empty parameter values preserve current LVM auto-select behavior (no behavior change for callers who don't opt in).
- Existing thin pools are unaffected — `chunk_size` cannot be changed after pool creation.
- The three new fields are additive on the CLI, in the volumeAction struct, and in the StorageClass params — no removal or rename.

## Test plan

- [x] Unit tests pass (`go test ./pkg/lvm/... -run TestBuildThinPoolCreateArgs -v`)
- [x] `go build ./...` clean
- [x] `go vet ./pkg/lvm/... ./cmd/provisioner/...` clean
- [x] `helm lint deploy/charts` clean
- [x] `helm template deploy/charts` renders both SCs correctly with parameters
- [ ] Existing bats integration suite (`tests/bats/`) — maintainers to verify on Linux CI (requires a real LVM device, cannot be run from macOS dev env)
- [ ] End-to-end on a Harvester cluster: create fresh VG → provision PVC → confirm `dmsetup table <vg>-thinpool-tpool` shows `skip_block_zeroing` and 1M chunk (`2048` sectors)

## Field evidence

Customer running everything from our runbook ended up with a 16 MiB chunk_size thin pool (LVM auto-select). Diskspd on comparable KubeVirt+VMDP+LVM hardware in our lab achieves 15,000+ QD1 4K IOPS with an explicit chunk size and `zero=n`; the customer's auto-selected pool measured 326 IOPS on the same workload class. The fix is setting an explicit, stripe-aligned chunk size at pool creation.

Related: harvester/harvester#11128 (LVM CSI cross-driver panic — separate bug, but same field investigation surfaced both).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
