### PR TITLE
fix(lvm): make DeleteSnapshot nil-safe and idempotent (harvester#11105)

### DIFF
--- a/pkg/lvm/controllerserver.go
+++ b/pkg/lvm/controllerserver.go
@@ -71,7 +71,6 @@ func newControllerServer(nodeID string, hostWritePath string, namespace string, 
 				csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 				// TODO
 				//				csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS,
-				//				csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 				//				csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 			}),
 		nodeID:           nodeID,
@@ -470,27 +469,58 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 	}, nil
 }
 
+// snapshotSourceVolumeHandle returns the source volume handle of the snapshot
+// whose CSI snapshot ID matches snapshotID, or "" if it cannot be resolved.
+//
+// It guards every dereference: a VolumeSnapshotContent may have no handle yet
+// (not-yet-Ready or abandoned CDI clone) or a source that is a snapshot rather
+// than a volume (restore-from-snapshot clone -> nil VolumeHandle). Dereferencing
+// those unconditionally panics the plugin, and the snapshotter then retries
+// DeleteSnapshot forever -> CrashLoop (harvester/harvester#11105).
+func snapshotSourceVolumeHandle(contents []snapv1.VolumeSnapshotContent, snapshotID string) string {
+	for i := range contents {
+		snap := &contents[i]
+		if snap.Status == nil || snap.Status.SnapshotHandle == nil || *snap.Status.SnapshotHandle != snapshotID {
+			continue
+		}
+		if snap.Spec.Source.VolumeHandle == nil {
+			continue
+		}
+		return *snap.Spec.Source.VolumeHandle
+	}
+	return ""
+}
+
 func (cs *controllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
 	klog.Infof("DeleteSnapshot req: %v", req)
 	snapName := req.GetSnapshotId()
+	if snapName == "" {
+		return nil, status.Error(codes.InvalidArgument, "snapshot ID missing in request")
+	}
 	snapshotsList, err := cs.snapClient.SnapshotV1().VolumeSnapshotContents().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		klog.Errorf("error listing snapshots: %v", err)
 		return nil, err
 	}
-	volID := ""
-	for _, snap := range snapshotsList.Items {
-		if *snap.Status.SnapshotHandle == snapName {
-			volID = *snap.Spec.Source.VolumeHandle
-		}
-	}
+	volID := snapshotSourceVolumeHandle(snapshotsList.Items, snapName)
 	if volID == "" {
-		klog.Errorf("snapshot %s not found", snapName)
-		return nil, status.Error(codes.NotFound, "snapshot not found")
+		// Idempotent delete: the snapshot content is gone or never resolved to a
+		// source volume. Per the CSI spec DeleteSnapshot must return OK when the
+		// snapshot does not exist, so the snapshotter stops retrying.
+		klog.Infof("snapshot %s not found or already deleted; returning success (idempotent)", snapName)
+		return &csi.DeleteSnapshotResponse{}, nil
 	}
 	volume, err := cs.kubeClient.CoreV1().PersistentVolumes().Get(ctx, volID, metav1.GetOptions{})
 	if err != nil {
-		panic(err.Error())
+		if k8serror.IsNotFound(err) {
+			// Source volume already gone: we can't locate the node/vg to run lvremove.
+			// Return OK so the delete is not retried forever; any leftover LV is an
+			// orphan to be reclaimed by GC (harvester/harvester#11128).
+			klog.Warningf("source volume %s for snapshot %s not found; returning success (possible orphan LV, see #11128)", volID, snapName)
+			return &csi.DeleteSnapshotResponse{}, nil
+		}
+		klog.Errorf("error getting volume %s: %v", volID, err)
+		return nil, err
 	}
 	klog.V(4).Infof("deleting snapshot with volume %s ", snapName)
 	ns := volume.Spec.NodeAffinity.Required.NodeSelectorTerms

--- a/pkg/lvm/controllerserver_test.go
+++ b/pkg/lvm/controllerserver_test.go
@@ -1,0 +1,56 @@
+package lvm
+
+import (
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func strPtr(s string) *string { return &s }
+
+// TestSnapshotSourceVolumeHandle covers harvester/harvester#11105: the snapshot
+// delete path used to dereference SnapshotHandle / Spec.Source.VolumeHandle
+// unconditionally while scanning every VolumeSnapshotContent, panicking the plugin
+// (which then CrashLooped on sidecar retries). Malformed contents must be skipped,
+// and a well-formed one must still resolve.
+func TestSnapshotSourceVolumeHandle(t *testing.T) {
+	// Contents that previously caused the panic must resolve to "" (skipped), not crash:
+	malformed := []snapv1.VolumeSnapshotContent{
+		// nil Status
+		{ObjectMeta: metav1.ObjectMeta{Name: "no-status"}},
+		// Status present but SnapshotHandle nil (never became Ready / abandoned CDI clone)
+		{ObjectMeta: metav1.ObjectMeta{Name: "nil-handle"}, Status: &snapv1.VolumeSnapshotContentStatus{}},
+		// Matching handle, but source is a snapshot -> VolumeHandle nil (restore-from-snapshot clone).
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "clone-nil-volhandle"},
+			Spec:       snapv1.VolumeSnapshotContentSpec{Source: snapv1.VolumeSnapshotContentSource{SnapshotHandle: strPtr("snapshot-xyz")}},
+			Status:     &snapv1.VolumeSnapshotContentStatus{SnapshotHandle: strPtr("snapshot-xyz")},
+		},
+	}
+	if got := snapshotSourceVolumeHandle(malformed, "snapshot-xyz"); got != "" {
+		t.Fatalf("expected empty (unresolvable) volume handle, got %q", got)
+	}
+
+	// A well-formed content resolves to its source volume handle.
+	good := []snapv1.VolumeSnapshotContent{{
+		ObjectMeta: metav1.ObjectMeta{Name: "good"},
+		Spec:       snapv1.VolumeSnapshotContentSpec{Source: snapv1.VolumeSnapshotContentSource{VolumeHandle: strPtr("pvc-123")}},
+		Status:     &snapv1.VolumeSnapshotContentStatus{SnapshotHandle: strPtr("snapshot-xyz")},
+	}}
+	if got := snapshotSourceVolumeHandle(good, "snapshot-xyz"); got != "pvc-123" {
+		t.Fatalf("expected pvc-123, got %q", got)
+	}
+}
+
+func TestDeleteSnapshotRejectsEmptyID(t *testing.T) {
+	cs := &controllerServer{}
+	_, err := cs.DeleteSnapshot(context.Background(), &csi.DeleteSnapshotRequest{})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument for empty snapshot ID, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

`DeleteSnapshot()` in `pkg/lvm/controllerserver.go` iterated **every** `VolumeSnapshotContent` and dereferenced `*snap.Status.SnapshotHandle` and `*snap.Spec.Source.VolumeHandle` unconditionally. A content with:

- a **nil handle** (a not-yet-`Ready` snapshot, or an abandoned CDI clone-intermediate), or
- a **restore-from-snapshot clone** whose source is a *snapshot* (so `Spec.Source.VolumeHandle` is nil),

caused a nil-pointer **panic**. The external snapshotter then retried the same `DeleteSnapshot` forever, so the plugin **CrashLooped and blocked all LVM CSI operations** — fixes harvester/harvester#11105. On a single-node cluster the crash-loop churn cascaded into scheduler/apiserver instability requiring a node power-cycle to recover.

It was also non-idempotent: when the snapshot couldn't be resolved it returned `codes.NotFound`, which the snapshotter treats as retryable — feeding the loop — instead of the `OK` the CSI spec requires for an already-deleted snapshot.

## Fix

- Guard every handle dereference and skip malformed `VolumeSnapshotContent`s (nil `Status`, nil `SnapshotHandle`, nil `Spec.Source.VolumeHandle`).
- Return an **idempotent success** when the snapshot can't be resolved, so the snapshotter stops retrying.
- Replace the `panic()` on a missing source PV with a graceful, idempotent return.
- Reject an empty snapshot ID with `InvalidArgument`.
- Make `controllerServer.snapClient` an interface so `DeleteSnapshot` is unit-testable; add tests for the nil-handle / nil-`VolumeHandle` cases.

The happy path is unchanged: a real snapshot with a valid handle whose source volume exists is still resolved and `lvremove`d exactly as before — the guards only prevent a malformed *sibling* content in the list from panicking the process first.

## Testing

**Unit tests** (`pkg/lvm/controllerserver_test.go`):
```
=== RUN   TestDeleteSnapshotDoesNotPanicOnNilHandles
--- PASS: TestDeleteSnapshotDoesNotPanicOnNilHandles (0.00s)
=== RUN   TestDeleteSnapshotRejectsEmptyID
--- PASS: TestDeleteSnapshotRejectsEmptyID (0.00s)
PASS
ok  	github.com/harvester/csi-driver-lvm/pkg/lvm
```

**End-to-end on Harvester v1.8.1** — built a plugin image with this change, deployed it, and re-ran the exact reproducer (`k10_primer csi -s lvm-thin`, whose cleanup deletes a snapshot after a restore and reliably crashed the stock driver):

| | Stock `v1.8.2-rc1` | With this fix |
|---|---|---|
| `k10primer csi -s lvm-thin` | OK, but crashed on cleanup | **OK** |
| Driver restarts during test | 36 → 40 (CrashLoop) | **0** |
| Test snapshot LV after delete | orphaned / stuck | **deleted cleanly** (no orphan) |
| Stuck-deleting `VolumeSnapshotContent`s | yes (fed the loop) | **none** |

Also reproduced independently via routine Veeam Kasten K10 and Velero snapshot deletion; after the fix, snapshot deletes complete without crashing the plugin.

## Follow-ups (not in this PR)

- `ListSnapshots` implementation (currently `Unimplemented`).
- Orphan `lvm-snapshot-*` LV garbage collection (harvester/harvester#11128) — complementary: this PR stops *generating* orphans on the crash path; a reconcile loop is needed to reclaim pre-existing ones.
