### PR TITLE
fix: prevent panic when deleting a CSI snapshot created from a statically bound volume

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,3 +5,5 @@ Before you start, you need to install the `harvester-csi-driver-lvm` first. For 
 Also, the examples contain some hardcode values. You need to modify them to fit your environment.
 - vgName: You nee to ensure the vgName was created in your environment.
 - nodeAffinity: You need to replace the value of the corresponding node name in your environment.
+
+For importing and deleting a pre-existing LVM snapshot through CSI snapshot objects, see [pre-existing-volume-snapshot.md](pre-existing-volume-snapshot.md).

--- a/examples/pre-existing-volume-snapshot-source.yaml
+++ b/examples/pre-existing-volume-snapshot-source.yaml
@@ -1,0 +1,79 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    cdi.harvesterhci.io/storageProfileCloneStrategy: snapshot
+    cdi.harvesterhci.io/storageProfileVolumeModeAccessModes: '{"Block":["ReadWriteOnce"]}'
+    cdi.harvesterhci.io/storageProfileVolumeSnapshotClass: lvm-snapshot
+  name: lvm-pre-existing-demo
+parameters:
+  type: dm-thin
+  vgName: vg1
+provisioner: lvm.driver.harvesterhci.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: false
+allowedTopologies:
+- matchLabelExpressions:
+  - key: topology.lvm.csi/node
+    values:
+    - hp-107-tink-system
+---
+apiVersion: snapshot.storage.k8s.io/v1
+deletionPolicy: Retain
+driver: lvm.driver.harvesterhci.io
+kind: VolumeSnapshotClass
+metadata:
+  name: lvm-snapshot-retain
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pre-existing-source-pvc
+  namespace: default
+spec:
+  storageClassName: lvm-pre-existing-demo
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  volumeMode: Block
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pre-existing-source-pod
+  namespace: default
+spec:
+  containers:
+    - name: ubuntu-jammy-container
+      image: ubuntu:jammy
+      command: ["/bin/bash", "-c", "--"]
+      args: ["while true; do sleep 30; done;"]
+      volumeDevices:
+        - devicePath: "/volumes/pre-existing-source-pvc"
+          name: pre-existing-source-pvc
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: topology.lvm.csi/node
+            operator: In
+            values:
+            - hp-107-tink-system
+  volumes:
+    - name: pre-existing-source-pvc
+      persistentVolumeClaim:
+        claimName: pre-existing-source-pvc
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: pre-existing-source-snapshot
+  namespace: default
+spec:
+  volumeSnapshotClassName: lvm-snapshot-retain
+  source:
+    persistentVolumeClaimName: pre-existing-source-pvc

--- a/examples/pre-existing-volume-snapshot.sh
+++ b/examples/pre-existing-volume-snapshot.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+	cat <<EOF
+Usage:
+  $0 <node-name> <vg-name>
+
+Environment variables:
+  NAMESPACE            Kubernetes namespace for demo objects. Default: default
+  DRIVER_NAMESPACE     Namespace where the LVM CSI driver is installed. Default: harvester-system
+  DRIVER_NAME          CSI provisioner/driver name. Default: lvm.driver.harvesterhci.io
+  TIMEOUT_SECONDS      Wait timeout in seconds. Default: 180
+  RUN_ID               Suffix for generated resource names. Default: current unix time
+  KEEP_DEMO_RESOURCES  Set to 1 to keep source PVC/classes after success.
+EOF
+}
+
+if [[ $# -ne 2 ]]; then
+	usage
+	exit 1
+fi
+
+NODE_NAME=$1
+VG_NAME=$2
+
+NAMESPACE=${NAMESPACE:-default}
+DRIVER_NAMESPACE=${DRIVER_NAMESPACE:-harvester-system}
+DRIVER_NAME=${DRIVER_NAME:-lvm.driver.harvesterhci.io}
+TIMEOUT_SECONDS=${TIMEOUT_SECONDS:-180}
+RUN_ID=${RUN_ID:-$(date +%s)}
+
+APP_LABEL=lvm-pre-existing-snapshot-demo
+SC_NAME="lvm-pre-existing-demo-${RUN_ID}"
+RETAIN_CLASS="lvm-snap-retain-${RUN_ID}"
+DELETE_CLASS="lvm-snap-delete-${RUN_ID}"
+PVC_NAME="pre-existing-source-pvc-${RUN_ID}"
+SOURCE_SNAPSHOT="pre-existing-source-snapshot-${RUN_ID}"
+IMPORT_CONTENT="pre-existing-import-content-${RUN_ID}"
+IMPORT_SNAPSHOT="pre-existing-import-${RUN_ID}"
+
+log() {
+	printf '\n==> %s\n' "$*"
+}
+
+if ! command -v kubectl >/dev/null 2>&1; then
+	printf 'missing required command: kubectl\n' >&2
+	exit 1
+fi
+
+wait_jsonpath() {
+	local kind=$1
+	local name=$2
+	local path=$3
+	local want=$4
+	local value
+
+	for _ in $(seq 1 "$TIMEOUT_SECONDS"); do
+		value=$(kubectl -n "$NAMESPACE" get "$kind" "$name" -o "jsonpath=${path}" 2>/dev/null || true)
+		if [[ "$value" == "$want" ]]; then
+			return 0
+		fi
+		sleep 1
+	done
+
+	printf 'timed out waiting for %s/%s jsonpath %s to be %s\n' "$kind" "$name" "$path" "$want" >&2
+	return 1
+}
+
+wait_jsonpath_nonempty() {
+	local kind=$1
+	local name=$2
+	local path=$3
+	local value
+
+	for _ in $(seq 1 "$TIMEOUT_SECONDS"); do
+		value=$(kubectl -n "$NAMESPACE" get "$kind" "$name" -o "jsonpath=${path}" 2>/dev/null || true)
+		if [[ -n "$value" ]]; then
+			printf '%s' "$value"
+			return 0
+		fi
+		sleep 1
+	done
+
+	printf 'timed out waiting for %s/%s jsonpath %s\n' "$kind" "$name" "$path" >&2
+	return 1
+}
+
+wait_cluster_jsonpath_nonempty() {
+	local kind=$1
+	local name=$2
+	local path=$3
+	local value
+
+	for _ in $(seq 1 "$TIMEOUT_SECONDS"); do
+		value=$(kubectl get "$kind" "$name" -o "jsonpath=${path}" 2>/dev/null || true)
+		if [[ -n "$value" ]]; then
+			printf '%s' "$value"
+			return 0
+		fi
+		sleep 1
+	done
+
+	printf 'timed out waiting for %s/%s jsonpath %s\n' "$kind" "$name" "$path" >&2
+	return 1
+}
+
+wait_namespaced_deleted() {
+	local kind=$1
+	local name=$2
+
+	for _ in $(seq 1 "$TIMEOUT_SECONDS"); do
+		if ! kubectl -n "$NAMESPACE" get "$kind" "$name" >/dev/null 2>&1; then
+			return 0
+		fi
+		sleep 1
+	done
+
+	printf 'timed out waiting for %s/%s to be deleted\n' "$kind" "$name" >&2
+	return 1
+}
+
+dump_snapshot_debug() {
+	local content
+
+	content=$(kubectl -n "$NAMESPACE" get volumesnapshot "$SOURCE_SNAPSHOT" -o jsonpath='{.status.boundVolumeSnapshotContentName}' 2>/dev/null || true)
+
+	cat <<EOF
+
+Snapshot did not become ready. Debug data:
+
+kubectl -n ${NAMESPACE} describe volumesnapshot ${SOURCE_SNAPSHOT}
+kubectl -n ${NAMESPACE} get volumesnapshot ${SOURCE_SNAPSHOT} -o yaml
+EOF
+
+	kubectl -n "$NAMESPACE" describe volumesnapshot "$SOURCE_SNAPSHOT" || true
+	kubectl -n "$NAMESPACE" get volumesnapshot "$SOURCE_SNAPSHOT" -o yaml || true
+
+	if [[ -n "$content" ]]; then
+		cat <<EOF
+
+kubectl describe volumesnapshotcontent ${content}
+kubectl get volumesnapshotcontent ${content} -o yaml
+EOF
+		kubectl describe volumesnapshotcontent "$content" || true
+		kubectl get volumesnapshotcontent "$content" -o yaml || true
+	fi
+
+	cat <<EOF
+
+Recent CSI snapshot helper pods:
+EOF
+	kubectl -n "$DRIVER_NAMESPACE" get pods | grep -E 'snap-create|snap-delete|lvm-create|lvm-delete' || true
+
+	cat <<EOF
+
+Recent csi-snapshotter logs:
+EOF
+	kubectl -n "$DRIVER_NAMESPACE" logs statefulset/harvester-csi-driver-lvm-controller -c csi-snapshotter --tail=120 || true
+}
+
+print_cleanup_hint() {
+	cat <<EOF
+
+The demo did not finish. To clean Kubernetes demo objects for RUN_ID=${RUN_ID}:
+
+kubectl -n ${NAMESPACE} delete pvc ${PVC_NAME} --ignore-not-found
+kubectl -n ${NAMESPACE} delete volumesnapshot ${SOURCE_SNAPSHOT} ${IMPORT_SNAPSHOT} --ignore-not-found
+kubectl delete volumesnapshotcontent ${SOURCE_CONTENT:-<source-content>} ${IMPORT_CONTENT} --ignore-not-found
+kubectl delete volumesnapshotclass ${RETAIN_CLASS} ${DELETE_CLASS} --ignore-not-found
+kubectl delete storageclass ${SC_NAME} --ignore-not-found
+EOF
+
+	if [[ -n "${LV_PATH:-}" ]]; then
+		cat <<EOF
+
+If the retained backend LV snapshot is still present and no longer has a VolumeSnapshotContent:
+
+ssh ${NODE_NAME} sudo lvremove -y /dev/${LV_PATH}
+EOF
+	fi
+}
+
+on_exit() {
+	local rc=$?
+
+	if [[ "$rc" -ne 0 ]]; then
+		print_cleanup_hint >&2
+	fi
+	exit "$rc"
+}
+
+cleanup_success() {
+	if [[ "${KEEP_DEMO_RESOURCES:-0}" == "1" ]]; then
+		return
+	fi
+
+	log "Cleaning up demo source resources"
+	kubectl -n "$NAMESPACE" delete pvc "$PVC_NAME" --ignore-not-found >/dev/null
+	kubectl delete volumesnapshotclass "$RETAIN_CLASS" --ignore-not-found >/dev/null
+	kubectl delete volumesnapshotclass "$DELETE_CLASS" --ignore-not-found >/dev/null
+	kubectl delete storageclass "$SC_NAME" --ignore-not-found >/dev/null
+}
+
+trap on_exit EXIT
+
+log "Using namespace=${NAMESPACE}, node=${NODE_NAME}, vg=${VG_NAME}"
+
+log "Creating source StorageClass, Retain snapshot class, and PVC"
+kubectl apply -f - <<EOF
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ${SC_NAME}
+  labels:
+    app.kubernetes.io/name: ${APP_LABEL}
+parameters:
+  type: dm-thin
+  vgName: ${VG_NAME}
+provisioner: ${DRIVER_NAME}
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowedTopologies:
+- matchLabelExpressions:
+  - key: topology.lvm.csi/node
+    values:
+    - ${NODE_NAME}
+---
+apiVersion: snapshot.storage.k8s.io/v1
+deletionPolicy: Retain
+driver: ${DRIVER_NAME}
+kind: VolumeSnapshotClass
+metadata:
+  name: ${RETAIN_CLASS}
+  labels:
+    app.kubernetes.io/name: ${APP_LABEL}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${PVC_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: ${APP_LABEL}
+spec:
+  storageClassName: ${SC_NAME}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  volumeMode: Block
+EOF
+
+log "Waiting for source PVC to bind"
+wait_jsonpath persistentvolumeclaim "$PVC_NAME" '{.status.phase}' Bound
+
+log "Creating CSI snapshot from PVC"
+kubectl apply -f - <<EOF
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: ${SOURCE_SNAPSHOT}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: ${APP_LABEL}
+spec:
+  volumeSnapshotClassName: ${RETAIN_CLASS}
+  source:
+    persistentVolumeClaimName: ${PVC_NAME}
+EOF
+
+log "Waiting for source snapshot"
+if ! wait_jsonpath volumesnapshot "$SOURCE_SNAPSHOT" '{.status.readyToUse}' true; then
+	dump_snapshot_debug
+	exit 1
+fi
+
+PV_NAME=$(kubectl -n "$NAMESPACE" get pvc "$PVC_NAME" -o jsonpath='{.spec.volumeName}')
+SOURCE_CONTENT=$(wait_jsonpath_nonempty volumesnapshot "$SOURCE_SNAPSHOT" '{.status.boundVolumeSnapshotContentName}')
+SNAPSHOT_HANDLE=$(wait_cluster_jsonpath_nonempty volumesnapshotcontent "$SOURCE_CONTENT" '{.status.snapshotHandle}')
+LV_PATH="${VG_NAME}/lvm-${SNAPSHOT_HANDLE}"
+
+log "Discovered values"
+printf 'PV_NAME=%s\nSOURCE_CONTENT=%s\nSNAPSHOT_HANDLE=%s\nLV_PATH=%s\n' \
+	"$PV_NAME" "$SOURCE_CONTENT" "$SNAPSHOT_HANDLE" "$LV_PATH"
+
+log "Optional manual backend check"
+printf 'ssh %s sudo lvs %s\n' "$NODE_NAME" "$LV_PATH"
+
+log "Deleting source VolumeSnapshot with Retain policy"
+kubectl -n "$NAMESPACE" delete volumesnapshot "$SOURCE_SNAPSHOT" --wait=false
+
+log "Waiting for source VolumeSnapshot to be fully removed"
+wait_namespaced_deleted volumesnapshot "$SOURCE_SNAPSHOT"
+
+log "Source snapshot deleted with Retain policy"
+printf 'Optional check that the backend snapshot is retained: ssh %s sudo lvs %s\n' "$NODE_NAME" "$LV_PATH"
+
+log "Importing retained LV snapshot as a pre-existing VolumeSnapshotContent"
+kubectl apply -f - <<EOF
+apiVersion: snapshot.storage.k8s.io/v1
+deletionPolicy: Delete
+driver: ${DRIVER_NAME}
+kind: VolumeSnapshotClass
+metadata:
+  name: ${DELETE_CLASS}
+  labels:
+    app.kubernetes.io/name: ${APP_LABEL}
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotContent
+metadata:
+  name: ${IMPORT_CONTENT}
+  labels:
+    app.kubernetes.io/name: ${APP_LABEL}
+  annotations:
+    lvm.driver.harvesterhci.io/nodeName: ${NODE_NAME}
+    lvm.driver.harvesterhci.io/vgName: ${VG_NAME}
+spec:
+  deletionPolicy: Delete
+  driver: ${DRIVER_NAME}
+  source:
+    snapshotHandle: ${SNAPSHOT_HANDLE}
+  volumeSnapshotClassName: ${DELETE_CLASS}
+  volumeSnapshotRef:
+    name: ${IMPORT_SNAPSHOT}
+    namespace: ${NAMESPACE}
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: ${IMPORT_SNAPSHOT}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: ${APP_LABEL}
+spec:
+  source:
+    volumeSnapshotContentName: ${IMPORT_CONTENT}
+  volumeSnapshotClassName: ${DELETE_CLASS}
+EOF
+
+log "Deleting imported snapshot and waiting for imported content deletion"
+kubectl -n "$NAMESPACE" delete volumesnapshot "$IMPORT_SNAPSHOT" --wait=true --timeout="${TIMEOUT_SECONDS}s"
+kubectl wait --for=delete "volumesnapshotcontent/${IMPORT_CONTENT}" --timeout="${TIMEOUT_SECONDS}s"
+
+log "Imported snapshot deleted"
+printf 'Optional check that the backend snapshot was removed: ssh %s sudo lvs %s\n' "$NODE_NAME" "$LV_PATH"
+
+log "Deleting retained source VolumeSnapshotContent"
+kubectl delete volumesnapshotcontent "$SOURCE_CONTENT" --ignore-not-found --wait=true --timeout="${TIMEOUT_SECONDS}s"
+
+cleanup_success
+
+log "Done"

--- a/examples/pre-existing-volume-snapshot.yaml
+++ b/examples/pre-existing-volume-snapshot.yaml
@@ -1,0 +1,26 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotContent
+metadata:
+  name: pre-existing-lvm-snapshot-content
+  annotations:
+    lvm.driver.harvesterhci.io/nodeName: <node-that-has-the-lv-snapshot>
+    lvm.driver.harvesterhci.io/vgName: <volume-group-name>
+spec:
+  deletionPolicy: Delete
+  driver: lvm.driver.harvesterhci.io
+  source:
+    snapshotHandle: <snapshot-name-without-lvm-prefix>
+  volumeSnapshotClassName: lvm-snapshot
+  volumeSnapshotRef:
+    name: pre-existing-lvm-snapshot
+    namespace: default
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: pre-existing-lvm-snapshot
+  namespace: default
+spec:
+  source:
+    volumeSnapshotContentName: pre-existing-lvm-snapshot-content
+  volumeSnapshotClassName: lvm-snapshot

--- a/pkg/lvm/controllerserver.go
+++ b/pkg/lvm/controllerserver.go
@@ -48,6 +48,11 @@ type controllerServer struct {
 	snapClient       *snapclient.Clientset
 }
 
+const (
+	snapshotNodeAnnotation = "lvm.driver.harvesterhci.io/nodeName"
+	snapshotVGAnnotation   = "lvm.driver.harvesterhci.io/vgName"
+)
+
 // NewControllerServer
 func newControllerServer(nodeID string, hostWritePath string, namespace string, provisionerImage string, pullPolicy v1.PullPolicy) (*controllerServer, error) {
 	config, err := rest.InClusterConfig()
@@ -473,31 +478,110 @@ func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 func (cs *controllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
 	klog.Infof("DeleteSnapshot req: %v", req)
 	snapName := req.GetSnapshotId()
-	snapshotsList, err := cs.snapClient.SnapshotV1().VolumeSnapshotContents().List(ctx, metav1.ListOptions{})
+
+	klog.V(4).Infof("deleting snapshot %s ", snapName)
+	sa, err := cs.deleteSnapshotAction(ctx, snapName)
+	if err != nil {
+		return nil, err
+	}
+	if err := createSnapshotterPod(ctx, sa); err != nil {
+		klog.Errorf("error creating provisioner pod :%v", err)
+		return nil, err
+	}
+
+	return &csi.DeleteSnapshotResponse{}, nil
+}
+
+func (cs *controllerServer) deleteSnapshotAction(
+	ctx context.Context,
+	snapName string,
+) (snapshotAction, error) {
+	snapContent, err := cs.getSnapContent(ctx, snapName)
+	if err != nil {
+		return snapshotAction{}, err
+	}
+
+	if snapContent.Spec.Source.VolumeHandle == nil {
+		return cs.delActionFromAnnotations(snapName, snapContent)
+	}
+
+	volID := *snapContent.Spec.Source.VolumeHandle
+	volume, err := cs.kubeClient.CoreV1().
+		PersistentVolumes().
+		Get(ctx, volID, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("error getting volume %s for snapshot %s: %v", volID, snapName, err)
+		return snapshotAction{}, err
+	}
+
+	return cs.delActionFromVolume(snapName, volume), nil
+}
+
+func (cs *controllerServer) getSnapContent(
+	ctx context.Context,
+	snapName string,
+) (*snapv1.VolumeSnapshotContent, error) {
+	snapshotsList, err := cs.snapClient.SnapshotV1().
+		VolumeSnapshotContents().
+		List(ctx, metav1.ListOptions{})
 	if err != nil {
 		klog.Errorf("error listing snapshots: %v", err)
 		return nil, err
 	}
-	volID := ""
-	for _, snap := range snapshotsList.Items {
-		if *snap.Status.SnapshotHandle == snapName {
-			volID = *snap.Spec.Source.VolumeHandle
+
+	for i := range snapshotsList.Items {
+		snap := &snapshotsList.Items[i]
+		if matchSnapContent(snap, snapName) {
+			return snap, nil
 		}
 	}
-	if volID == "" {
-		klog.Errorf("snapshot %s not found", snapName)
-		return nil, status.Error(codes.NotFound, "snapshot not found")
+
+	klog.Errorf("snapshot %s not found", snapName)
+	return nil, status.Error(codes.NotFound, "snapshot not found")
+}
+
+func matchSnapContent(snapContent *snapv1.VolumeSnapshotContent, snapName string) bool {
+	if snapContent.Status != nil &&
+		snapContent.Status.SnapshotHandle != nil &&
+		*snapContent.Status.SnapshotHandle == snapName {
+		return true
 	}
-	volume, err := cs.kubeClient.CoreV1().PersistentVolumes().Get(ctx, volID, metav1.GetOptions{})
-	if err != nil {
-		panic(err.Error())
-	}
-	klog.V(4).Infof("deleting snapshot with volume %s ", snapName)
+	return snapContent.Spec.Source.SnapshotHandle != nil &&
+		*snapContent.Spec.Source.SnapshotHandle == snapName
+}
+
+func (cs *controllerServer) delActionFromVolume(
+	snapName string,
+	volume *v1.PersistentVolume,
+) snapshotAction {
 	ns := volume.Spec.NodeAffinity.Required.NodeSelectorTerms
 	node := ns[0].MatchExpressions[0].Values[0]
 	vgName := volume.Spec.CSI.VolumeAttributes["vgName"]
 
-	sa := snapshotAction{
+	return cs.newDelSnapshotAction(snapName, node, vgName)
+}
+
+func (cs *controllerServer) delActionFromAnnotations(
+	snapName string,
+	snapContent *snapv1.VolumeSnapshotContent,
+) (snapshotAction, error) {
+	node := snapContent.Annotations[snapshotNodeAnnotation]
+	vgName := snapContent.Annotations[snapshotVGAnnotation]
+	if node == "" || vgName == "" {
+		return snapshotAction{}, status.Errorf(
+			codes.FailedPrecondition,
+			"pre-existing snapshot %s requires annotations %s and %s",
+			snapName,
+			snapshotNodeAnnotation,
+			snapshotVGAnnotation,
+		)
+	}
+
+	return cs.newDelSnapshotAction(snapName, node, vgName), nil
+}
+
+func (cs *controllerServer) newDelSnapshotAction(snapName, node, vgName string) snapshotAction {
+	return snapshotAction{
 		action:           actionTypeDelete,
 		snapshotName:     snapName,
 		nodeName:         node,
@@ -509,12 +593,6 @@ func (cs *controllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteS
 		provisionerImage: cs.provisionerImage,
 		pullPolicy:       cs.pullPolicy,
 	}
-	if err := createSnapshotterPod(ctx, sa); err != nil {
-		klog.Errorf("error creating provisioner pod :%v", err)
-		return nil, err
-	}
-
-	return &csi.DeleteSnapshotResponse{}, nil
 }
 
 func (cs *controllerServer) ListSnapshots(_ context.Context, _ *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {


### PR DESCRIPTION


<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
LVM CSI driver DeleteSnapshot panics and Orphan lvm-snapshot LVs

#### Solution:
Prevent a panic when deleting a CSI snapshot created from a statically bound volume, and require the node and VG annotations for statically bound VSCs.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/11105
https://github.com/harvester/harvester/issues/11128


#### Test plan:

Tested the pre-existing LVM snapshot import/delete flow using the example manifests added in this PR.

1. Rendered and applied the source manifest with the target node and VG:
    ```
    NODE_NAME=NODE_THAT_HAS_THE_VOLUME_GROUP
    VG_NAME=VOLUME_GROUP_NAME
    
    sed \
      -e "s/NODE_THAT_HAS_THE_VOLUME_GROUP/$NODE_NAME/g" \
      -e "s/VOLUME_GROUP_NAME/$VG_NAME/g" \
      examples/pre-existing-volume-snapshot-source.yaml > /tmp/pre-existing-volume-snapshot-source.yaml
      ```

2. Waited for the source pod, prepared the block PVC inside the pod, then created a CSI VolumeSnapshot with deletionPolicy: Retain.
    ```
    kubectl apply -f /tmp/pre-existing-volume-snapshot-source.yaml
    kubectl wait -n default --for=condition=Ready pod/pre-existing-source-pod --timeout=120s
    ```
    
    ```
    kubectl exec -it -n default pre-existing-source-pod -- bash
    
    mkfs.ext4 /volumes/pre-existing-source-pvc
    mkdir -p /mnt/source
    mount /volumes/pre-existing-source-pvc /mnt/source
    echo "hello from the source volume" > /mnt/source/hello.txt
    sync
    umount /mnt/source
    exit
    ```
    ```
    kubectl apply -f - <<EOF
    apiVersion: snapshot.storage.k8s.io/v1
    kind: VolumeSnapshot
    metadata:
      name: pre-existing-source-snapshot
      namespace: default
    spec:
      volumeSnapshotClassName: lvm-snapshot-retain
      source:
        persistentVolumeClaimName: pre-existing-source-pvc
    EOF
    
    kubectl wait -n default --for=jsonpath='{.status.readyToUse}'=true volumesnapshot/pre-existing-source-snapshot --timeout=120s
    ```

3. Rendered and applied the pre-existing snapshot manifest using the discovered snapshotHandle, node name, VG name, 
    ```
    PVC=pre-existing-source-pvc
    SOURCE_SNAPSHOT=pre-existing-source-snapshot
    
    PV=$(kubectl get pvc -n default "$PVC" -o jsonpath='{.spec.volumeName}')
    STORAGE_CLASS=$(kubectl get pvc -n default "$PVC" -o jsonpath='{.spec.storageClassName}')
    SOURCE_CONTENT=$(kubectl get volumesnapshot -n default "$SOURCE_SNAPSHOT" -o jsonpath='{.status.boundVolumeSnapshotContentName}')
    SNAPSHOT_HANDLE=$(kubectl get volumesnapshotcontent "$SOURCE_CONTENT" -o jsonpath='{.status.snapshotHandle}')
    
    printf 'NODE_NAME=%s\nVG_NAME=%s\nSTORAGE_CLASS=%s\nSOURCE_CONTENT=%s\nSNAPSHOT_HANDLE=%s\n' \
      "$NODE_NAME" "$VG_NAME" "$STORAGE_CLASS" "$SOURCE_CONTENT" "$SNAPSHOT_HANDLE"
    ```
 
4. Deleted the source VolumeSnapshot and verified the backend LV snapshot was retained.
    ```
    kubectl delete volumesnapshot -n default "$SOURCE_SNAPSHOT"
    kubectl wait -n default --for=delete volumesnapshot/"$SOURCE_SNAPSHOT" --timeout=120s
    
    ssh "$NODE_NAME" sudo lvs "$VG_NAME/lvm-$SNAPSHOT_HANDLE"
    ```

5. Import the retained LV snapshot as a pre-existing VolumeSnapshot, and Verified the imported VolumeSnapshot restored into a block PVC and could be attached to a pod.
    ```
    sed \
      -e "s/NODE_THAT_HAS_THE_LV_SNAPSHOT/$NODE_NAME/g" \
      -e "s/VOLUME_GROUP_NAME/$VG_NAME/g" \
      -e "s/SNAPSHOT_NAME_WITHOUT_LVM_PREFIX/$SNAPSHOT_HANDLE/g" \
      -e "s/LVM_STORAGE_CLASS_NAME/$STORAGE_CLASS/g" \
      -e "s/RESTORE_PVC_SIZE/1Gi/g" \
      examples/pre-existing-volume-snapshot.yaml > /tmp/pre-existing-volume-snapshot-import.yaml
    
    kubectl apply -f /tmp/pre-existing-volume-snapshot-import.yaml
    kubectl get volumesnapshot -n default pre-existing-lvm-snapshot
    kubectl get volumesnapshotcontent pre-existing-lvm-snapshot-content -o yaml
    kubectl wait -n default --for=jsonpath='{.status.phase}'=Bound pvc/pre-existing-lvm-snapshot-restore --timeout=120s
    kubectl wait -n default --for=condition=Ready pod/pre-existing-lvm-snapshot-restore-pod --timeout=120s
    ```
    
    The pre-existing VolumeSnapshotContent must include the driver metadata annotations so the CSI driver can locate and delete the backend LV snapshot:
    ```
    metadata:
      annotations:
        lvm.driver.harvesterhci.io/nodeName: <node-name>
        lvm.driver.harvesterhci.io/vgName: <vg-name>
    ```
  
    If the restored block PVC contains a filesystem, you can inspect and mount it inside the pod:
    ```
    kubectl exec -it -n default pre-existing-lvm-snapshot-restore-pod -- \
      lsblk /volumes/pre-existing-lvm-snapshot-restore
    
    kubectl exec -it -n default pre-existing-lvm-snapshot-restore-pod -- \
      mkdir -p /mnt/restore
    
    kubectl exec -it -n default pre-existing-lvm-snapshot-restore-pod -- \
      mount /volumes/pre-existing-lvm-snapshot-restore /mnt/restore
    ```
  
6. Deleted the restored pod/PVC, then deleted the imported VolumeSnapshot.
    ```
    kubectl delete pod -n default pre-existing-lvm-snapshot-restore-pod
    kubectl delete pvc -n default pre-existing-lvm-snapshot-restore
    kubectl delete volumesnapshot -n default pre-existing-lvm-snapshot
    
    kubectl wait --for=delete volumesnapshotcontent/pre-existing-lvm-snapshot-content --timeout=120s
    ssh "$NODE_NAME" sudo lvs "$VG_NAME/lvm-$SNAPSHOT_HANDLE"
    ```

    The final lvs command should fail with "not found" or equivalent output because the imported snapshot deletion should remove the backend LV snapshot.

7. Clean up the created resources
    ```
    kubectl delete pod -n default pre-existing-lvm-snapshot-restore-pod --ignore-not-found
    kubectl delete pvc -n default pre-existing-lvm-snapshot-restore --ignore-not-found
    kubectl delete volumesnapshot -n default pre-existing-lvm-snapshot --ignore-not-found
    kubectl delete volumesnapshotcontent pre-existing-lvm-snapshot-content --ignore-not-found
    
    kubectl delete volumesnapshot -n default "$SOURCE_SNAPSHOT" --ignore-not-found
    kubectl delete volumesnapshotcontent "$SOURCE_CONTENT" --ignore-not-found
    kubectl delete pod -n default pre-existing-source-pod --ignore-not-found
    kubectl delete pvc -n default pre-existing-source-pvc --ignore-not-found
    
    kubectl delete volumesnapshotclass lvm-snapshot-retain --ignore-not-found
    kubectl delete storageclass lvm-pre-existing-demo --ignore-not-found
    
    rm -f /tmp/pre-existing-volume-snapshot-source.yaml
    rm -f /tmp/pre-existing-volume-snapshot-import.yaml
    ```